### PR TITLE
Adds action for publishing image to ghcr.io registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+
+name: Build Collector Docker Image
+
+on:
+  # manually triggered by GitHub Action menu for testing/validation
+  workflow_dispatch:
+  #push:
+  #  branches:
+  #    - 'main'
+
+jobs:
+  Deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and Push Demo Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          push: true # Pushes after image build
+          context: ./
+          tags: |
+            ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN /go/bin/opentelemetry-collector-builder --config /build/config/builder-confi
 FROM debian:stretch-slim
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates
+    && apt-get install -y --no-install-recommends ca-certificates
 
 RUN update-ca-certificates
 
@@ -23,7 +23,7 @@ COPY --from=builder /build/build/telemetry-generator .
 COPY --from=builder /build/generatorreceiver/topos/* /etc/otel/
 COPY --from=builder /build/config/collector-config.yml /etc/otel/config.yaml
 
-ENV TOPO_FILE=/etc/otel/hipster_shop.json
+ENV TOPO_FILE=/etc/otel/hipster_shop.yaml
 ENV OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=ingest.lightstep.com:443
 ENV OTEL_INSECURE=false
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites & setup
 
-### Opentelemetry collector builder
+### OpenTelemetry collector builder
 Install the `opentelemetry-collector-builder`; this is deprecated but its replacement does not work with the old version of the collector we're still pinned to.
    1. `$ cd /tmp` (or wherever you like to keep code)
    1. `$ git clone https://github.com/open-telemetry/opentelemetry-collector-builder`
@@ -79,3 +79,16 @@ $ docker run --rm -e LS_ACCESS_TOKEN -e OTEL_EXPORTER_OTLP_TRACES_ENDPOINT -e TO
 ```
 
 When building with Docker, you need to re-run both steps for any code *or* config changes. If you run into errors while building, please open [an issue](https://github.com/lightstep/telemetry-generator).
+
+### Non-development Workflow: Run a published image
+
+If you just want to run (vs build or develop), you can run the most recent image published to this repository's container registry. 
+
+For defaults, see `Dockerfile`.
+
+```shell
+$ export LS_ACCESS_TOKEN=your token
+# can override to any other OTLP endpoint
+$ export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=ingest.lightstep.com:443
+$ docker run -e LS_ACCESS_TOKEN --rm lightstep/telemetry-generator:latest
+```

--- a/README.md
+++ b/README.md
@@ -90,5 +90,5 @@ For defaults, see `Dockerfile`.
 $ export LS_ACCESS_TOKEN=your token
 # can override to any other OTLP endpoint
 $ export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=ingest.lightstep.com:443
-$ docker run -e LS_ACCESS_TOKEN --rm lightstep/telemetry-generator:latest
+$ docker run -e LS_ACCESS_TOKEN --rm ghcr.io/lightstep//telemetry-generator:latest
 ```


### PR DESCRIPTION
Small PR to add a image publish action to the container registry for this repo so the generator can be used by various container platforms (or locally) without building (ECS, EKS, AppRun, etc).

When a `workflow_dispatch` event is manually triggered event via the actions menu, an action builds and publishes the image to this repo's ghcr.io registry (will automatically appear in repo under "Packages")

_note_: this is for the github registry (ghcr.io) not the google cloud registry (gcr.io).