### PR TITLE
LS-34071: align flag enable time and kubernetes restart time

### DIFF
--- a/generatorreceiver/generator_receiver.go
+++ b/generatorreceiver/generator_receiver.go
@@ -144,14 +144,10 @@ func (g *generatorReceiver) startMetricGenerator(ctx context.Context, host compo
 	// TODO: do we actually need to generate every second?
 	metricTicker := time.NewTicker(topology.DefaultMetricTickerPeriod)
 	go func() {
-		g.logger.Info("generating metrics", zap.String("service", serviceName), zap.String("name", m.Name))
+		g.logger.Info("generating metrics", zap.String("service", serviceName), zap.String("name", m.Name), zap.String("flag_set", m.EmbeddedFlags.FlagSet), zap.String("flag_unset", m.EmbeddedFlags.FlagUnset))
 		metricGen := generator.NewMetricGenerator()
 		for range metricTicker.C {
-			if m.Kubernetes != nil && m.Kubernetes.Restart.Every != 0 {
-				if time.Since(m.Kubernetes.StartTime) >= m.Kubernetes.Restart.Every {
-					m.Kubernetes.RestartPod()
-				}
-			}
+			m.Kubernetes.RestartIfNeeded(m.EmbeddedFlags, g.logger)
 
 			if metrics, report := metricGen.Generate(&m, serviceName); report {
 				err := g.metricConsumer.ConsumeMetrics(ctx, metrics)

--- a/generatorreceiver/internal/flags/flag.go
+++ b/generatorreceiver/internal/flags/flag.go
@@ -7,11 +7,6 @@ import (
 	"time"
 )
 
-const (
-	DisabledState = 0.0
-	EnabledState  = 1.0
-)
-
 // TODO: separate config types from code types generally
 
 type IncidentConfig struct {
@@ -34,6 +29,7 @@ type FlagConfig struct {
 type Flag struct {
 	cfg     FlagConfig
 	started time.Time
+	updated time.Time
 	mu      sync.Mutex
 }
 
@@ -89,11 +85,15 @@ func (f *Flag) CurrentDuration() time.Duration {
 func (f *Flag) Enable() {
 	if !f.active() {
 		f.started = time.Now()
+		f.updated = time.Now()
 	}
 }
 
 func (f *Flag) Disable() {
-	f.started = time.Time{}
+	if f.active() {
+		f.started = time.Time{}
+		f.updated = time.Now()
+	}
 }
 
 func (f *Flag) Toggle() {

--- a/generatorreceiver/internal/flags/flag_embed.go
+++ b/generatorreceiver/internal/flags/flag_embed.go
@@ -1,6 +1,9 @@
 package flags
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 type EmbeddedFlags struct {
 	FlagSet   string `json:"flag_set" yaml:"flag_set"`
@@ -24,6 +27,21 @@ func (f *EmbeddedFlags) ShouldGenerate() bool {
 
 func (f *EmbeddedFlags) IsDefault() bool {
 	return f.FlagSet == "" && f.FlagUnset == ""
+}
+
+func (f *EmbeddedFlags) UpdatedTime() time.Time {
+	if f.FlagSet != "" {
+		if set := Manager.GetFlag(f.FlagSet); set != nil {
+			return set.updated
+		}
+	}
+	if f.FlagUnset != "" {
+		if unset := Manager.GetFlag(f.FlagUnset); unset != nil {
+			return unset.updated
+		}
+	}
+
+	return time.Time{}
 }
 
 func (f *EmbeddedFlags) ValidateFlags() error {

--- a/generatorreceiver/internal/flags/flag_test.go
+++ b/generatorreceiver/internal/flags/flag_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"testing"
+	"time"
 )
 
 func TestFlagManager_ValidateFlags(t *testing.T) {
@@ -119,5 +120,89 @@ func TestEmbeddedFlags_Validate(t *testing.T) {
 				assert.Fail(t, "expected validation error")
 			}
 		})
+	}
+}
+
+func TestEmbeddedFlags_GenerateTime(t *testing.T) {
+	Manager.Clear()
+
+	Manager.LoadFlags([]FlagConfig{
+		{
+			Name: "flag_a",
+		},
+		{
+			Name: "flag_b",
+		},
+	}, zap.NewNop())
+
+	a := Manager.GetFlag("flag_a")
+	b := Manager.GetFlag("flag_b")
+
+	ef := EmbeddedFlags{
+		FlagSet:   "flag_a",
+		FlagUnset: "flag_b",
+	}
+
+	a.Enable()
+	b.Enable()
+	if st := ef.GenerateStartTime().UnixNano(); st != 0 {
+		assert.Fail(t, "'b' is enabled, start time should be 0")
+	}
+
+	a.Disable()
+	b.Disable()
+	if st := ef.GenerateStartTime().UnixNano(); st != 0 {
+		assert.Fail(t, "'a' is disabled, start time should be 0")
+	}
+
+	a.Disable()
+	b.Enable()
+	if st := ef.GenerateStartTime().UnixNano(); st != 0 {
+		assert.Fail(t, "'a' is disabled and 'b' is enabled, start time should be 0")
+	}
+
+	a.Enable()
+	time.Sleep(10 * time.Millisecond)
+	b.Disable()
+	if st := ef.GenerateStartTime().UnixNano(); st != b.updated.UnixNano() {
+		assert.Fail(t, "start time should be the same as the time that the last flag was set.")
+	}
+
+	a.Disable()
+	b.Enable()
+
+	b.Disable()
+	time.Sleep(10 * time.Millisecond)
+	a.Enable()
+	if st := ef.GenerateStartTime().UnixNano(); st != a.updated.UnixNano() {
+		assert.Fail(t, "start time should be the same as the time that the last flag was set.")
+	}
+
+	ef = EmbeddedFlags{
+		FlagSet: "flag_a",
+	}
+
+	a.Enable()
+	if st := ef.GenerateStartTime().UnixNano(); st != a.updated.UnixNano() {
+		assert.Fail(t, "generate start time should be equal 'a'.")
+	}
+
+	a.Disable()
+	if st := ef.GenerateStartTime().UnixNano(); st != 0 {
+		assert.Fail(t, "'a' is disabled, generate start time should be 0.")
+	}
+
+	ef = EmbeddedFlags{
+		FlagUnset: "flag_b",
+	}
+
+	b.Disable()
+	if st := ef.GenerateStartTime().UnixNano(); st != b.updated.UnixNano() {
+		assert.Fail(t, "generate start time should be equal 'b'.")
+	}
+
+	b.Enable()
+	if st := ef.GenerateStartTime().UnixNano(); st != 0 {
+		assert.Fail(t, "'b' is enabled, generate start time should be 0.")
 	}
 }

--- a/generatorreceiver/internal/topology/kubernetes.go
+++ b/generatorreceiver/internal/topology/kubernetes.go
@@ -82,7 +82,7 @@ func (k *Kubernetes) RestartIfNeeded(flags flags.EmbeddedFlags, logger *zap.Logg
 	k.mutex.Lock()
 	defer k.mutex.Unlock()
 
-	flagTime := flags.UpdatedTime()
+	flagTime := flags.GenerateStartTime()
 	if flagTime.After(k.StartTime) {
 		// consider that the pod started at the time that a flag was enabled/disabled.
 		k.restartPod(logger)


### PR DESCRIPTION
Fix a bug where the kubernetes restart timer would begin from the collector start time instead of the time that its flag was enabled/disabled