### PR TITLE
Multi-pod support

### DIFF
--- a/examples/hipster_shop.yaml
+++ b/examples/hipster_shop.yaml
@@ -18,7 +18,8 @@ topology:
       resourceAttrSets:
         - weight: 1
           kubernetes:
-            cluster_name: k8s-cluster-1
+            pod_count: 7
+            cluster_name: k8s-cluster-23
             request:
               cpu: 0.5
               memory: 2048
@@ -162,7 +163,7 @@ topology:
                 error: true
                 http.status_code: 503
             - weight: 85
-              tags: {}
+              tags:
           maxLatencyMillis: 400
     recommendationservice:
       tagSets:
@@ -262,7 +263,7 @@ topology:
                 error: true
                 http.status_code: 503
             - weight: 85
-              tags: {}
+              tags:
           maxLatencyMillis: 500
     paymentservice:
       tagSets:
@@ -574,3 +575,7 @@ rootRoutes:
   - service: android  
     route: /api/make-payment
     tracesPerHour: 480
+
+config:
+  kubernetes:
+    pod_count: 1

--- a/examples/hipster_shop.yaml
+++ b/examples/hipster_shop.yaml
@@ -19,6 +19,9 @@ topology:
         - weight: 1
           kubernetes:
             pod_count: 7
+            restart:
+              every: 10m
+              jitter: 2m
             cluster_name: k8s-cluster-23
             request:
               cpu: 0.5
@@ -464,8 +467,8 @@ topology:
         /api/payment-status:
           maxLatencyMillis: 100
     android:
-      resourceAttrs:
-        - weight: 1 
+      resourceAttrSets:
+        - weight: 1
           resourceAttrs:
             instrument.name: lighstep
             http.method: POST

--- a/generatorreceiver/generator_receiver.go
+++ b/generatorreceiver/generator_receiver.go
@@ -69,7 +69,8 @@ func (g generatorReceiver) Start(ctx context.Context, host component.Host) error
 
 	for _, s := range topoFile.Topology.Services {
 		for i := range s.ResourceAttributeSets {
-			s.ResourceAttributeSets[i].Kubernetes.CreatePod(s.ServiceName)
+			s.ResourceAttributeSets[i].Kubernetes.Cfg = topoFile.Config
+			s.ResourceAttributeSets[i].Kubernetes.CreatePods(s.ServiceName)
 		}
 	}
 
@@ -134,7 +135,7 @@ func (g *generatorReceiver) startMetricGenerator(ctx context.Context, host compo
 		g.logger.Info("generating metrics", zap.String("service", serviceName), zap.String("name", m.Name), zap.String("flag_set", m.EmbeddedFlags.FlagSet), zap.String("flag_unset", m.EmbeddedFlags.FlagUnset))
 		metricGen := generator.NewMetricGenerator()
 		for range metricTicker.C {
-			m.Kubernetes.RestartIfNeeded(m.EmbeddedFlags, g.logger)
+			m.Pod.RestartIfNeeded(m.EmbeddedFlags, g.logger)
 
 			if metrics, report := metricGen.Generate(&m, serviceName); report {
 				err := g.metricConsumer.ConsumeMetrics(ctx, metrics)

--- a/generatorreceiver/internal/topology/file.go
+++ b/generatorreceiver/internal/topology/file.go
@@ -13,9 +13,11 @@ type File struct {
 }
 
 type Config struct {
-	Kubernetes struct {
-		PodCount int64 `json:"pod_count" yaml:"pod_count"`
-	}
+	Kubernetes *KubernetesConfig
+}
+
+type KubernetesConfig struct {
+	PodCount int `json:"pod_count" yaml:"pod_count"`
 }
 
 type RootRoute struct {

--- a/generatorreceiver/internal/topology/file.go
+++ b/generatorreceiver/internal/topology/file.go
@@ -9,6 +9,13 @@ type File struct {
 	Topology   *Topology          `json:"topology" yaml:"topology"`
 	Flags      []flags.FlagConfig `json:"flags" yaml:"flags"`
 	RootRoutes []RootRoute        `json:"rootRoutes" yaml:"rootRoutes"`
+	Config     *Config            `json:"config" yaml:"config"`
+}
+
+type Config struct {
+	Kubernetes struct {
+		PodCount int64 `json:"pod_count" yaml:"pod_count"`
+	}
 }
 
 type RootRoute struct {

--- a/generatorreceiver/internal/topology/kubernetes_test.go
+++ b/generatorreceiver/internal/topology/kubernetes_test.go
@@ -3,6 +3,7 @@ package topology
 import (
 	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 )
 
 func TestReplaceTags(t *testing.T) {
@@ -44,4 +45,60 @@ func TestReplaceTags(t *testing.T) {
 		},
 		tags,
 	)
+}
+
+func TestMultiPod(t *testing.T) {
+	nPods := 7
+	minute, _ := time.ParseDuration("1m")
+	tenMinute, _ := time.ParseDuration("10m")
+	k := &Kubernetes{
+		ClusterName: "some-cluster",
+		Restart: Restart{
+			Every:  tenMinute,
+			Jitter: minute,
+		},
+		PodCount: nPods,
+	}
+	k.CreatePods("some")
+
+	// we should see more than one pod name in the tags
+	// (odds of this test failing randomly are 1 in 7**100 =~ 3 in 10^85
+	names := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		tags := k.GetK8sTags()
+		names[tags["k8s.pod.name"]] = true
+	}
+	require.Greater(t, len(names), 1, "multiple pod names should be generated")
+
+	// we should see different restart durations
+	// (odds of this test failing randomly are 1 in (60e9)**6 =~ 5 in 10^64)
+	unequal := false
+	for i := 1; i < nPods; i++ {
+		unequal = unequal || (k.pods[i].RestartDuration != k.pods[0].RestartDuration)
+	}
+	require.True(t, unequal, "different restart durations should be set")
+
+	k = &Kubernetes{
+		ClusterName: "some-cluster",
+		Restart: Restart{
+			Every:  tenMinute,
+			Jitter: minute,
+		},
+		Cfg: &Config{
+			Kubernetes: &KubernetesConfig{
+				PodCount: 2,
+			},
+		},
+	}
+	k.CreatePods("some")
+	require.Equal(t, 2, k.GetPodCount(), "pod count defaults to config value")
+	k = &Kubernetes{
+		ClusterName: "some-cluster",
+		Restart: Restart{
+			Every:  tenMinute,
+			Jitter: minute,
+		},
+	}
+	k.CreatePods("some")
+	require.Equal(t, 1, k.GetPodCount(), "pod count defaults to 1 if no config value")
 }

--- a/generatorreceiver/internal/topology/kubernetes_test.go
+++ b/generatorreceiver/internal/topology/kubernetes_test.go
@@ -7,16 +7,21 @@ import (
 
 func TestReplaceTags(t *testing.T) {
 	k := &Kubernetes{
-		PodName:        "testapp-abbab-abb",
 		Service:        "testapp-service",
 		Namespace:      "testapp-namespace",
-		Container:      "testapp-container",
 		ClusterName:    "testapp-cluster",
 		ReplicaSetName: "testapp-replica",
+		pods:           make([]*Pod, 0, 1),
 	}
+	pod := Pod{
+		PodName:    "testapp-abbab-abb",
+		Container:  "testapp-container",
+		Kubernetes: k,
+	}
+	k.pods = append(k.pods, &pod)
 
 	tags := map[string]string{
-		"my_pod":       Pod,
+		"my_pod":       PodName,
 		"my_service":   Service,
 		"my_namespace": Namespace,
 		"my_container": Container,
@@ -25,7 +30,7 @@ func TestReplaceTags(t *testing.T) {
 		"my_key":       "my_value",
 	}
 
-	tags = k.ReplaceTags(tags)
+	tags = k.pods[0].ReplaceTags(tags)
 
 	require.Equal(t,
 		map[string]string{

--- a/generatorreceiver/internal/topology/metric.go
+++ b/generatorreceiver/internal/topology/metric.go
@@ -24,19 +24,19 @@ func (fs *funcShape) GetValue(phase float64) float64 {
 }
 
 type leakingShape struct {
-	average    ShapeInterface
-	kubernetes *Kubernetes
+	average ShapeInterface
+	pod     *Pod
 }
 
 func (ls *leakingShape) GetValue(phase float64) float64 {
-	if ls.kubernetes == nil {
+	if ls.pod == nil {
 		return ls.average.GetValue(phase)
 	}
 
-	timeAlive := time.Since(ls.kubernetes.StartTime)
+	timeAlive := time.Since(ls.pod.StartTime)
 
 	// Start at 35% and increase it to 100% right before the restart time.
-	factor := .35 + float64(timeAlive)/float64(ls.kubernetes.Restart.Every)*.7
+	factor := .35 + float64(timeAlive)/float64(ls.pod.Kubernetes.Restart.Every)*.7
 
 	return factor
 }
@@ -64,12 +64,12 @@ type Metric struct {
 	Tags                map[string]string `json:"tags" yaml:"tags"`
 	Jitter              float64           `json:"jitter" yaml:"jitter"`
 	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
-	Kubernetes          *Kubernetes
+	Pod                 *Pod
 }
 
 func (m *Metric) GetTags() map[string]string {
-	if m.Kubernetes != nil {
-		return m.Kubernetes.ReplaceTags(m.Tags)
+	if m.Pod != nil {
+		return m.Pod.ReplaceTags(m.Tags)
 	}
 
 	return m.Tags
@@ -92,7 +92,7 @@ func (m *Metric) InitMetric() {
 	case Average:
 		m.ShapeInterface = &funcShape{AverageValue}
 	case Leaking:
-		m.ShapeInterface = &leakingShape{average: &funcShape{AverageValue}, kubernetes: m.Kubernetes}
+		m.ShapeInterface = &leakingShape{average: &funcShape{AverageValue}, pod: m.Pod}
 	default:
 		// TODO: what would be a reasonable default? Maybe just sine?
 		m.ShapeInterface = &funcShape{SineValue}

--- a/generatorreceiver/internal/topology/metric.go
+++ b/generatorreceiver/internal/topology/metric.go
@@ -36,7 +36,7 @@ func (ls *leakingShape) GetValue(phase float64) float64 {
 	timeAlive := time.Since(ls.pod.StartTime)
 
 	// Start at 35% and increase it to 100% right before the restart time.
-	factor := .35 + float64(timeAlive)/float64(ls.pod.Kubernetes.Restart.Every)*.7
+	factor := .35 + float64(timeAlive)/float64(ls.pod.RestartDuration)*.7
 
 	return factor
 }

--- a/generatorreceiver/internal/topology/service_route.go
+++ b/generatorreceiver/internal/topology/service_route.go
@@ -8,13 +8,12 @@ import (
 )
 
 type ServiceRoute struct {
-	Route                 string                 `json:"route" yaml:"route"`
-	DownstreamCalls       []Call                 `json:"downstreamCalls,omitempty" yaml:"downstreamCalls,omitempty"`
-	MaxLatencyMillis      int64                  `json:"maxLatencyMillis" yaml:"maxLatencyMillis"`
-	LatencyConfigs        LatencyConfigs         `json:"latencyConfigs" yaml:"latencyConfigs"`
-	TagSets               []TagSet               `json:"tagSets" yaml:"tagSets"`
-	ResourceAttributeSets []ResourceAttributeSet `json:"resourceAttrSets" yaml:"resourceAttrSets"`
-	flags.EmbeddedFlags   `json:",inline" yaml:",inline"`
+	Route               string         `json:"route" yaml:"route"`
+	DownstreamCalls     []Call         `json:"downstreamCalls,omitempty" yaml:"downstreamCalls,omitempty"`
+	MaxLatencyMillis    int64          `json:"maxLatencyMillis" yaml:"maxLatencyMillis"`
+	LatencyConfigs      LatencyConfigs `json:"latencyConfigs" yaml:"latencyConfigs"`
+	TagSets             []TagSet       `json:"tagSets" yaml:"tagSets"`
+	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
 	// TODO: rename all references from `tag` to `attribute`, to follow the otel standard.
 }
 


### PR DESCRIPTION
## What is the current behavior?
Each `kubernetes` section is associated with exactly one virtual pod.

## What is the new behavior?
An option `pod_count` attribute can be used to create multiple virtual pods per `kubernetes` section, and a global value controls the default `pod_count`.

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->