### PR TITLE
Repo was renamed but the code didn't get the memo

### DIFF
--- a/config/builder-config.yml
+++ b/config/builder-config.yml
@@ -1,12 +1,12 @@
 dist:
-    module: github.com/lightstep/demo-environment # the module name for the new distribution, following Go mod conventions. Optional, but recommended.
+    module: github.com/lightstep/telemetry-generator # the module name for the new distribution, following Go mod conventions. Optional, but recommended.
     name: telemetry-generator
     description: "Custom Lightstep Partner OpenTelemetry Collector distribution" # a long name for the application. Optional.
     include_core: true # whether the core components should be included in the distribution. Optional.
     output_path: build # the path to write the output (sources and binary). Optional.
     version: "0.0.1" # the version for your custom OpenTelemetry Collector. Optional.
 receivers:
-  - gomod: "github.com/lightstep/demo-environment/generatorreceiver v0.0.1"
+  - gomod: "github.com/lightstep/telemetry-generator/generatorreceiver v0.0.1"
     name: "generatorreceiver"
     path: "./generatorreceiver"
 processors:

--- a/generatorreceiver/generator_receiver.go
+++ b/generatorreceiver/generator_receiver.go
@@ -3,13 +3,13 @@ package generatorreceiver
 import (
 	"context"
 	"fmt"
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/cron"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/cron"
 	"math/rand"
 	"time"
 
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/generator"
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/topology"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/generator"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/topology"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenterror"
 	"go.opentelemetry.io/collector/consumer"

--- a/generatorreceiver/go.mod
+++ b/generatorreceiver/go.mod
@@ -1,4 +1,4 @@
-module github.com/lightstep/demo-environment/generatorreceiver
+module github.com/lightstep/telemetry-generator/generatorreceiver
 
 go 1.18
 

--- a/generatorreceiver/helper.go
+++ b/generatorreceiver/helper.go
@@ -2,7 +2,7 @@ package generatorreceiver
 
 import (
 	"fmt"
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/topology"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/topology"
 	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"os"

--- a/generatorreceiver/internal/flags/flag.go
+++ b/generatorreceiver/internal/flags/flag.go
@@ -2,7 +2,7 @@ package flags
 
 import (
 	"fmt"
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/cron"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/cron"
 	"go.uber.org/zap"
 	"strings"
 	"sync"

--- a/generatorreceiver/internal/generator/metric_generator.go
+++ b/generatorreceiver/internal/generator/metric_generator.go
@@ -1,7 +1,7 @@
 package generator
 
 import (
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/topology"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/topology"
 	"time"
 
 	"go.opentelemetry.io/collector/model/pdata"

--- a/generatorreceiver/internal/generator/trace_generator.go
+++ b/generatorreceiver/internal/generator/trace_generator.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/topology"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/topology"
 	"go.opentelemetry.io/collector/model/pdata"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 )

--- a/generatorreceiver/internal/topology/file.go
+++ b/generatorreceiver/internal/topology/file.go
@@ -2,7 +2,7 @@ package topology
 
 import (
 	"fmt"
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 )
 
 type File struct {

--- a/generatorreceiver/internal/topology/kubernetes.go
+++ b/generatorreceiver/internal/topology/kubernetes.go
@@ -1,7 +1,7 @@
 package topology
 
 import (
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 	"go.uber.org/zap"
 	"math"
 	"math/rand"

--- a/generatorreceiver/internal/topology/latency_percentiles.go
+++ b/generatorreceiver/internal/topology/latency_percentiles.go
@@ -1,7 +1,7 @@
 package topology
 
 import (
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 	"math/rand"
 	"time"
 )

--- a/generatorreceiver/internal/topology/metric.go
+++ b/generatorreceiver/internal/topology/metric.go
@@ -1,7 +1,7 @@
 package topology
 
 import (
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 	"math"
 	"math/rand"
 	"time"

--- a/generatorreceiver/internal/topology/metric_test.go
+++ b/generatorreceiver/internal/topology/metric_test.go
@@ -1,7 +1,7 @@
 package topology
 
 import (
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 	"go.uber.org/zap"
 	"testing"
 )

--- a/generatorreceiver/internal/topology/resource_attribute_set.go
+++ b/generatorreceiver/internal/topology/resource_attribute_set.go
@@ -1,7 +1,7 @@
 package topology
 
 import (
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 )
 
 type ResourceAttributeSet struct {

--- a/generatorreceiver/internal/topology/service_route.go
+++ b/generatorreceiver/internal/topology/service_route.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 )
 
 type ServiceRoute struct {

--- a/generatorreceiver/internal/topology/service_route_test.go
+++ b/generatorreceiver/internal/topology/service_route_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 )

--- a/generatorreceiver/internal/topology/tag_set.go
+++ b/generatorreceiver/internal/topology/tag_set.go
@@ -1,7 +1,7 @@
 package topology
 
 import (
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 )
 
 type TagSet struct {

--- a/generatorreceiver/server.go
+++ b/generatorreceiver/server.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/lightstep/demo-environment/generatorreceiver/internal/flags"
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
 	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 )


### PR DESCRIPTION
## What is the current behavior?
Things are broken.

More specifically, the import paths, go.mod and builder config reference a non-existent repository.

## What is the new behavior?
Things are not broken.

More specifically, the import paths, go.mod and builder config reference the actual repository.

---
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
