### PR TITLE
changed go get to go install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.19.1 as builder
 RUN mkdir /build
 WORKDIR /build
 
-RUN GO111MODULE=on go get github.com/open-telemetry/opentelemetry-collector-builder@v0.35.0
+RUN GO111MODULE=on go install github.com/open-telemetry/opentelemetry-collector-builder@v0.35.0
 
 ADD . .
 


### PR DESCRIPTION
go get is deprecated as of Go 1.18


## What is the current behavior?
Previously we were on Go 1.17 where `go get` was supported, however recent PR updated our Go Version to 1.19m deprecating go get.


## What is the new behavior?
using go install instead.

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->