### PR TITLE
Don't try getting K8sTags if no resource attribute sets were defined

### DIFF
--- a/generatorreceiver/internal/topology/kubernetes.go
+++ b/generatorreceiver/internal/topology/kubernetes.go
@@ -140,6 +140,10 @@ func (k *Kubernetes) randomPod() *Pod {
 
 // only called from tag generator!
 func (k *Kubernetes) GetK8sTags() map[string]string {
+	if k.pods == nil {
+		return map[string]string{}
+	}
+
 	k.mutex.Lock()
 	defer k.mutex.Unlock()
 


### PR DESCRIPTION
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
If a service in the YAML does not have `resourceAttrSets` defined or if that list doesn’t contain at least one item, it panics when we try appending Kubernetes tags. This is because in`GetK8sTags()`, we try to capture the tags from a random pod (and pods are only created per resource attribute set, so if there are none, no pods are created).

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
`GetK8sTags()` returns an empty map if a service does not have any `resourceAttrSets`.

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## How to test?
Delete a service's `resourceAttrSets` from your working config file. Observe panic. Apply the change from this PR and try again. Observe no error.

