### PR TITLE
Don't create pods when kubernetes section isn't defined

### DIFF
--- a/generatorreceiver/generator_receiver.go
+++ b/generatorreceiver/generator_receiver.go
@@ -69,8 +69,12 @@ func (g generatorReceiver) Start(ctx context.Context, host component.Host) error
 
 	for _, s := range topoFile.Topology.Services {
 		for i := range s.ResourceAttributeSets {
-			s.ResourceAttributeSets[i].Kubernetes.Cfg = topoFile.Config
-			s.ResourceAttributeSets[i].Kubernetes.CreatePods(s.ServiceName)
+			k := s.ResourceAttributeSets[i].Kubernetes
+			if k == nil {
+				continue
+			}
+			k.Cfg = topoFile.Config
+			k.CreatePods(s.ServiceName)
 		}
 	}
 
@@ -87,6 +91,9 @@ func (g generatorReceiver) Start(ctx context.Context, host component.Host) error
 			for i := range s.ResourceAttributeSets {
 				resource := &s.ResourceAttributeSets[i]
 				// For each resource generate k8s metrics if enabled
+				if resource.Kubernetes == nil {
+					continue
+				}
 				k8sMetrics := resource.Kubernetes.GenerateMetrics()
 				for i := range k8sMetrics {
 					// keep the same flags as the resources.

--- a/generatorreceiver/internal/topology/resource_attribute_set.go
+++ b/generatorreceiver/internal/topology/resource_attribute_set.go
@@ -5,8 +5,8 @@ import (
 )
 
 type ResourceAttributeSet struct {
-	Kubernetes          Kubernetes `json:"kubernetes" yaml:"kubernetes"`
-	ResourceAttributes  TagMap     `json:"resourceAttrs,omitempty" yaml:"resourceAttrs,omitempty"`
+	Kubernetes          *Kubernetes `json:"kubernetes" yaml:"kubernetes"`
+	ResourceAttributes  TagMap      `json:"resourceAttrs,omitempty" yaml:"resourceAttrs,omitempty"`
 	EmbeddedWeight      `json:",inline" yaml:",inline"`
 	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
 }
@@ -16,10 +16,10 @@ func (r *ResourceAttributeSet) GetAttributes() *TagMap {
 	for k, v := range r.ResourceAttributes {
 		tm[k] = v
 	}
-
-	for k, v := range r.Kubernetes.GetK8sTags() {
-		tm[k] = v
+	if k8s := r.Kubernetes; k8s != nil {
+		for k, v := range k8s.GetK8sTags() {
+			tm[k] = v
+		}
 	}
-
 	return &tm
 }

--- a/generatorreceiver/internal/topology/resource_attribute_set_test.go
+++ b/generatorreceiver/internal/topology/resource_attribute_set_test.go
@@ -1,0 +1,82 @@
+package topology
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceAttributeSet_GetAttributes(t *testing.T) {
+	tests := []struct {
+		name               string
+		service            string
+		resourceAttributes TagMap
+		kubernetes         *Kubernetes
+		expected           TagMap
+	}{
+		{
+			name:    "resource attributes and kubernetes both defined",
+			service: "fake-service",
+			resourceAttributes: map[string]interface{}{
+				"cloud":  "nimbus",
+				"region": "us-central1",
+			},
+			kubernetes: &Kubernetes{
+				ClusterName: "cluster-1",
+				Cfg: &Config{
+					Kubernetes: &KubernetesConfig{
+						PodCount: 1,
+					},
+				},
+			},
+			expected: TagMap{
+				"cloud":               "nimbus",
+				"region":              "us-central1",
+				"k8s.cluster.name":    "cluster-1",
+				"k8s.container.name":  "fake-service",
+				"k8s.namespace.name":  "fake-service",
+				"k8s.deployment.name": "",
+			},
+		},
+		{
+			name:    "resource attributes defined but not kubernetes",
+			service: "some-service",
+			resourceAttributes: map[string]interface{}{
+				"cloud":  "nimbus",
+				"region": "europe-west1",
+			},
+			kubernetes: nil,
+			expected: TagMap{
+				"cloud":  "nimbus",
+				"region": "europe-west1",
+			},
+		},
+		{
+			name:               "neither resource attributes nor kubernetes defined",
+			service:            "another-service",
+			resourceAttributes: map[string]interface{}{},
+			kubernetes:         nil,
+			expected:           TagMap{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resourceAttrSet := ResourceAttributeSet{
+				Kubernetes:         tt.kubernetes,
+				ResourceAttributes: tt.resourceAttributes,
+			}
+
+			if k := resourceAttrSet.Kubernetes; k != nil {
+				rand.Seed(123)
+				k.CreatePods(tt.service)
+
+				// k8s.pod.name structure was copied from CreatePods()
+				rand.Seed(123)
+				tt.expected["k8s.pod.name"] = tt.service + "-" + generateK8sName(10) + "-" + generateK8sName(5)
+			}
+
+			require.Equal(t, tt.expected, *resourceAttrSet.GetAttributes())
+		})
+	}
+}


### PR DESCRIPTION
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
We currently create pods per each set of resource attributes, whether or not they have a `kubernetes` section defined (in YAML config).

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `ResourceAttributeSet.Kubernetes` is now of type `*Kubernetes` instead of `Kubernetes`
- Create pods, generate k8s metrics, and append k8s tags for a given `ResourceAttributeSet` **only** when it has a `kubernetes` section defined
- (Also added test for `ResourceAttributeSet.GetAttributes()`)

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [X] No