### PR TITLE
Decrease the rate of metric points generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+* Metric points are now generated every 15 seconds, instead of every second.
+
 
 ## [0.11.3](https://github.com/lightstep/telemetry-generator/releases/tag/v0.11.3) - 2022-10-20
 ### Added

--- a/generatorreceiver/internal/topology/metric.go
+++ b/generatorreceiver/internal/topology/metric.go
@@ -9,7 +9,7 @@ import (
 
 const DefaultPeriod = 60 * time.Minute
 const DefaultOffset = 0 * time.Minute
-const DefaultMetricTickerPeriod = 1 * time.Second
+const DefaultMetricTickerPeriod = 15 * time.Second
 
 type ShapeInterface interface {
 	GetValue(phase float64) float64


### PR DESCRIPTION
## What is the current behavior?
Currently, metrics generates a metric point every second.

## What is the new behavior?
For each timeseries, generate a metric point every 15 seconds. Although there are cases where this high precision is interesting, for our case a point each 15s is more than enough. This also reduces the costs for running and storing these metrics.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
