### PR TITLE
update tag script to also tag generatorreceiver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ add-tag:
 	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
 	@echo "Adding tag ${TAG}"
 	@git tag -a ${TAG} -m "Version ${TAG}"
+	@git tag -a generatorreceiver/${TAG} -m "Version ${TAG} for module generatorreceiver"
 
 
 .PHONY: push-tag
@@ -20,6 +21,7 @@ push-tag:
 	@[ "${TAG}" ] || ( echo ">> env var TAG is not set"; exit 1 )
 	@echo "Pushing tag ${TAG}"
 	@git push git@github.com:lightstep/telemetry-generator.git ${TAG}
+	@git push git@github.com:lightstep/telemetry-generator.git generatorreceiver/${TAG}
 
 .PHONY: install-otel-builder
 install-otel-builder:


### PR DESCRIPTION
## What is the current behavior?
Our tagging script only creates a tag `vx.y.z`. But since the `generatorreceiver` is not at root of this repository, the `vx.y.z` tag is not valid for that go module, making it impossible to import the `generatorreceiver` with a tag, ending with a commit hash instead, like:
```
github.com/lightstep/telemetry-generator/generatorreceiver v0.0.0-20221013030504-7e0cea697832
```


## What is the new behavior?
Update the `make add-tag` script to add tags for the `generatorreceiver` module as well, the list of tags created now will be:

- `vx.y.z`
- `generatorreceiver/vx.y.z`

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
