### PR TITLE
Fix Dockerfile default topology path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=builder /build/build/telemetry-generator .
 COPY --from=builder /build/config/collector-config.yml /etc/otel/config.yaml
 COPY --from=builder /build/examples/* /otel/examples/
 
-ENV TOPO_FILE=/etc/otel/hipster_shop.yaml
+ENV TOPO_FILE=/otel/examples/hipster_shop.yaml
 ENV OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=ingest.lightstep.com:443
 ENV OTEL_INSECURE=false
 


### PR DESCRIPTION
## What is the current behavior?

* Default docker command doesn't run, file path specified in `TOPO_FILE` does not exist.


## What is the new behavior?

* Fixes `TOPO_FILE` to point to bundled topology file in new directory.

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->