### PR TITLE
LS-31645 Add test for trace generator func

### DIFF
--- a/generatorreceiver/internal/generator/trace_generator_test.go
+++ b/generatorreceiver/internal/generator/trace_generator_test.go
@@ -97,7 +97,7 @@ func TestTraceGenerator_createSpanForServiceRouteCall2(t *testing.T) {
 		},
 
 		{
-			name: "span with downstream calls",
+			name: "span without downstream calls",
 			args: args{
 				serviceName:    "frontend",
 				routeName:      "/checkout",

--- a/generatorreceiver/internal/generator/trace_generator_test.go
+++ b/generatorreceiver/internal/generator/trace_generator_test.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -68,81 +67,13 @@ var topologyTestRecommendationService = topology.ServiceTier{
 	},
 }
 
-// func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
-
-// 	type args struct {
-// 		serviceName    string
-// 		routeName      string
-// 		startTimeNanos int64
-// 	}
-
-// 	tests := []struct {
-// 		name string
-// 		topo *topology.Topology
-// 		args args
-// 	}{
-// 		{
-// 			name: "span with downstream calls",
-// 			topo: &topology.Topology{
-// 				Services: map[string]*topology.ServiceTier{
-// 					"frontend":              &topologyTestFrontend,
-// 					"productcatalogservice": &topologyTestCatalogService,
-// 					"recommendationservice": &topologyTestRecommendationService,
-// 				},
-// 			},
-// 			args: args{
-// 				serviceName:    "frontend",
-// 				routeName:      "/product",
-// 				startTimeNanos: 000000123,
-// 			},
-// 		},
-// 	}
-
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			traces := ptrace.NewTraces()
-// 			g := NewTraceGenerator(tt.topo, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
-// 			genTraceID := g.genTraceId()
-// 			span := g.createSpanForServiceRouteCall(&traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
-// 			convertedSpanStartTime := pcommon.NewTimestampFromTime(time.Unix(0, tt.args.startTimeNanos))
-
-// 			require.Equal(t, span.StartTimestamp(), convertedSpanStartTime)
-// 			require.Equal(t, span.Name(), tt.args.routeName)
-// 			require.Equal(t, span.TraceID(), genTraceID)
-// 			require.Equal(t, span.ParentSpanID(), pcommon.NewSpanIDEmpty()) //root span will have parent span id of 0
-
-// 			resourceSpans := traces.ResourceSpans()
-// 			serviceTier := tt.topo.Services
-// 			indexResourceSpans := 0
-// 			childSpan := resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0)
-
-// 			if childSpan.ParentSpanID() != pcommon.NewSpanIDEmpty() {
-// 				require.Equal(t, childSpan.ParentSpanID(), span.SpanID())
-// 			}
-
-// 			for _, service := range serviceTier {
-
-// 				if len(service.TagSets) > 0 {
-// 					for tagKey, tagValue := range service.TagSets[0].Tags {
-// 						retrievedTagValue, exists := childSpan.Attributes().Get(tagKey)
-// 						require.Equal(t, tagValue, retrievedTagValue.AsString())
-// 						require.True(t, exists)
-// 					}
-// 				}
-
-// 				_, exists := service.Routes[childSpan.Name()]
-// 				require.True(t, exists)
-
-// 				childSpanStartTime := childSpan.StartTimestamp()
-// 				require.LessOrEqual(t, span.StartTimestamp(), childSpanStartTime)
-// 				childSpanEndTime := childSpan.EndTimestamp() //there are no children of children so index 0
-// 				require.GreaterOrEqual(t, span.EndTimestamp(), childSpanEndTime)
-// 				indexResourceSpans++
-// 			}
-
-// 		})
-// 	}
-// }
+var testTopology = &topology.Topology{
+	Services: map[string]*topology.ServiceTier{
+		"frontend":              &topologyTestFrontend,
+		"productcatalogservice": &topologyTestCatalogService,
+		"recommendationservice": &topologyTestRecommendationService,
+	},
+}
 
 func TestTraceGenerator_createSpanForServiceRouteCall2(t *testing.T) {
 
@@ -154,21 +85,22 @@ func TestTraceGenerator_createSpanForServiceRouteCall2(t *testing.T) {
 
 	tests := []struct {
 		name string
-		topo *topology.Topology
 		args args
 	}{
 		{
 			name: "span with downstream calls",
-			topo: &topology.Topology{
-				Services: map[string]*topology.ServiceTier{
-					"frontend":              &topologyTestFrontend,
-					"productcatalogservice": &topologyTestCatalogService,
-					"recommendationservice": &topologyTestRecommendationService,
-				},
-			},
 			args: args{
 				serviceName:    "frontend",
 				routeName:      "/product",
+				startTimeNanos: 000000123,
+			},
+		},
+
+		{
+			name: "span with downstream calls",
+			args: args{
+				serviceName:    "frontend",
+				routeName:      "/checkout",
 				startTimeNanos: 000000123,
 			},
 		},
@@ -177,7 +109,7 @@ func TestTraceGenerator_createSpanForServiceRouteCall2(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			traces := ptrace.NewTraces()
-			g := NewTraceGenerator(tt.topo, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
+			g := NewTraceGenerator(testTopology, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
 			genTraceID := g.genTraceId()
 			rootSpan := g.createSpanForServiceRouteCall(&traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
 			convertedSpanStartTime := pcommon.NewTimestampFromTime(time.Unix(0, tt.args.startTimeNanos))
@@ -188,34 +120,33 @@ func TestTraceGenerator_createSpanForServiceRouteCall2(t *testing.T) {
 			require.Equal(t, rootSpan.ParentSpanID(), pcommon.NewSpanIDEmpty()) //root span will have parent span id of 0
 
 			resourceSpans := traces.ResourceSpans()
-
 			for i := 1; i < resourceSpans.Len(); i++ {
 
-				childSpan := resourceSpans.At(i).ScopeSpans().At(0).Spans().At(0)
-				require.Equal(t, childSpan.ParentSpanID(), rootSpan.SpanID())
-				childSpanStartTime := childSpan.StartTimestamp()
+				resourceSpan := resourceSpans.At(i)
+				scopeSpan := resourceSpan.ScopeSpans().At(0).Spans().At(0)
+				require.Equal(t, scopeSpan.ParentSpanID(), rootSpan.SpanID())
+				childSpanStartTime := scopeSpan.StartTimestamp()
 				require.LessOrEqual(t, rootSpan.StartTimestamp(), childSpanStartTime)
-				childSpanEndTime := childSpan.EndTimestamp()
+				childSpanEndTime := scopeSpan.EndTimestamp()
 				require.GreaterOrEqual(t, rootSpan.EndTimestamp(), childSpanEndTime)
-				require.Equal(t, childSpan.TraceID(), genTraceID)
+				require.Equal(t, scopeSpan.TraceID(), genTraceID)
 
-				service := getServiceFromRoute(childSpan.Name(), *tt.topo)
-				fmt.Println(service)
-				fmt.Printf("%+v\n", childSpan)
+				serviceName, ok := resourceSpan.Resource().Attributes().Get("service.name")
+				require.True(t, ok)
+				service, ok := testTopology.Services[serviceName.AsString()]
+				require.True(t, ok)
+				_, ok = service.Routes[scopeSpan.Name()]
+				require.True(t, ok)
+
+				if len(service.TagSets) > 0 {
+					for tagKey, tagValue := range service.TagSets[0].Tags {
+						retrievedTagValue, exists := scopeSpan.Attributes().Get(tagKey)
+						require.Equal(t, tagValue, retrievedTagValue.AsString())
+						require.True(t, exists)
+					}
+				}
 
 			}
 		})
 	}
-}
-
-func getServiceFromRoute(route string, topo topology.Topology) topology.ServiceTier {
-
-	for _, service := range topo.Services {
-		for _, serviceRoute := range service.Routes {
-			if route == serviceRoute.Route {
-				return *service
-			}
-		}
-	}
-	return topology.ServiceTier{}
 }

--- a/generatorreceiver/internal/generator/trace_generator_test.go
+++ b/generatorreceiver/internal/generator/trace_generator_test.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -12,6 +13,8 @@ import (
 )
 
 var topologyTestFrontend = topology.ServiceTier{
+
+	ServiceName: "frontend",
 	Routes: map[string]*topology.ServiceRoute{
 		"/product": {
 			DownstreamCalls: []topology.Call{
@@ -34,6 +37,7 @@ var topologyTestFrontend = topology.ServiceTier{
 }
 
 var topologyTestCatalogService = topology.ServiceTier{
+	ServiceName: "productcatalogservice",
 	Routes: map[string]*topology.ServiceRoute{
 		"/GetProducts": {
 			MaxLatencyMillis: 5,
@@ -50,6 +54,7 @@ var topologyTestCatalogService = topology.ServiceTier{
 }
 
 var topologyTestRecommendationService = topology.ServiceTier{
+	ServiceName: "recommendationservice",
 	Routes: map[string]*topology.ServiceRoute{
 		"/GetRecommendations": {MaxLatencyMillis: 10},
 	},
@@ -63,7 +68,83 @@ var topologyTestRecommendationService = topology.ServiceTier{
 	},
 }
 
-func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
+// func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
+
+// 	type args struct {
+// 		serviceName    string
+// 		routeName      string
+// 		startTimeNanos int64
+// 	}
+
+// 	tests := []struct {
+// 		name string
+// 		topo *topology.Topology
+// 		args args
+// 	}{
+// 		{
+// 			name: "span with downstream calls",
+// 			topo: &topology.Topology{
+// 				Services: map[string]*topology.ServiceTier{
+// 					"frontend":              &topologyTestFrontend,
+// 					"productcatalogservice": &topologyTestCatalogService,
+// 					"recommendationservice": &topologyTestRecommendationService,
+// 				},
+// 			},
+// 			args: args{
+// 				serviceName:    "frontend",
+// 				routeName:      "/product",
+// 				startTimeNanos: 000000123,
+// 			},
+// 		},
+// 	}
+
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			traces := ptrace.NewTraces()
+// 			g := NewTraceGenerator(tt.topo, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
+// 			genTraceID := g.genTraceId()
+// 			span := g.createSpanForServiceRouteCall(&traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
+// 			convertedSpanStartTime := pcommon.NewTimestampFromTime(time.Unix(0, tt.args.startTimeNanos))
+
+// 			require.Equal(t, span.StartTimestamp(), convertedSpanStartTime)
+// 			require.Equal(t, span.Name(), tt.args.routeName)
+// 			require.Equal(t, span.TraceID(), genTraceID)
+// 			require.Equal(t, span.ParentSpanID(), pcommon.NewSpanIDEmpty()) //root span will have parent span id of 0
+
+// 			resourceSpans := traces.ResourceSpans()
+// 			serviceTier := tt.topo.Services
+// 			indexResourceSpans := 0
+// 			childSpan := resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0)
+
+// 			if childSpan.ParentSpanID() != pcommon.NewSpanIDEmpty() {
+// 				require.Equal(t, childSpan.ParentSpanID(), span.SpanID())
+// 			}
+
+// 			for _, service := range serviceTier {
+
+// 				if len(service.TagSets) > 0 {
+// 					for tagKey, tagValue := range service.TagSets[0].Tags {
+// 						retrievedTagValue, exists := childSpan.Attributes().Get(tagKey)
+// 						require.Equal(t, tagValue, retrievedTagValue.AsString())
+// 						require.True(t, exists)
+// 					}
+// 				}
+
+// 				_, exists := service.Routes[childSpan.Name()]
+// 				require.True(t, exists)
+
+// 				childSpanStartTime := childSpan.StartTimestamp()
+// 				require.LessOrEqual(t, span.StartTimestamp(), childSpanStartTime)
+// 				childSpanEndTime := childSpan.EndTimestamp() //there are no children of children so index 0
+// 				require.GreaterOrEqual(t, span.EndTimestamp(), childSpanEndTime)
+// 				indexResourceSpans++
+// 			}
+
+// 		})
+// 	}
+// }
+
+func TestTraceGenerator_createSpanForServiceRouteCall2(t *testing.T) {
 
 	type args struct {
 		serviceName    string
@@ -98,43 +179,43 @@ func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
 			traces := ptrace.NewTraces()
 			g := NewTraceGenerator(tt.topo, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
 			genTraceID := g.genTraceId()
-			span := g.createSpanForServiceRouteCall(&traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
+			rootSpan := g.createSpanForServiceRouteCall(&traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
 			convertedSpanStartTime := pcommon.NewTimestampFromTime(time.Unix(0, tt.args.startTimeNanos))
 
-			require.Equal(t, span.StartTimestamp(), convertedSpanStartTime)
-			require.Equal(t, span.Name(), tt.args.routeName)
-			require.Equal(t, span.TraceID(), genTraceID)
-			require.Equal(t, span.ParentSpanID(), pcommon.NewSpanIDEmpty()) //root span will have parent span id of 0
+			require.Equal(t, rootSpan.StartTimestamp(), convertedSpanStartTime)
+			require.Equal(t, rootSpan.Name(), tt.args.routeName)
+			require.Equal(t, rootSpan.TraceID(), genTraceID)
+			require.Equal(t, rootSpan.ParentSpanID(), pcommon.NewSpanIDEmpty()) //root span will have parent span id of 0
 
 			resourceSpans := traces.ResourceSpans()
-			serviceTier := tt.topo.Services
-			indexResourceSpans := 0
 
-			for serviceName, value := range serviceTier {
+			for i := 1; i < resourceSpans.Len(); i++ {
 
-				if len(value.TagSets) > 0 {
-					for tagKey, tagValue := range value.TagSets[0].Tags {
-						retrievedTagValue, exists := resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).Attributes().Get(tagKey)
-						require.Equal(t, tagValue, retrievedTagValue.AsString())
-						require.True(t, exists)
-					}
-				}
+				childSpan := resourceSpans.At(i).ScopeSpans().At(0).Spans().At(0)
+				require.Equal(t, childSpan.ParentSpanID(), rootSpan.SpanID())
+				childSpanStartTime := childSpan.StartTimestamp()
+				require.LessOrEqual(t, rootSpan.StartTimestamp(), childSpanStartTime)
+				childSpanEndTime := childSpan.EndTimestamp()
+				require.GreaterOrEqual(t, rootSpan.EndTimestamp(), childSpanEndTime)
+				require.Equal(t, childSpan.TraceID(), genTraceID)
 
-				for route := range serviceTier[serviceName].Routes {
-					require.Equal(t, resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).Name(), route)
-				}
+				service := getServiceFromRoute(childSpan.Name(), *tt.topo)
+				fmt.Println(service)
+				fmt.Printf("%+v\n", childSpan)
 
-				if resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).ParentSpanID() != pcommon.NewSpanIDEmpty() {
-					require.Equal(t, resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).ParentSpanID(), span.SpanID())
-				}
-
-				childSpanStartTime := resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).StartTimestamp()
-				require.LessOrEqual(t, span.StartTimestamp(), childSpanStartTime)
-				childSpanEndTime := resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).EndTimestamp() //there are no children of children so index 0
-				require.GreaterOrEqual(t, span.EndTimestamp(), childSpanEndTime)
-				indexResourceSpans++
 			}
-
 		})
 	}
+}
+
+func getServiceFromRoute(route string, topo topology.Topology) topology.ServiceTier {
+
+	for _, service := range topo.Services {
+		for _, serviceRoute := range service.Routes {
+			if route == serviceRoute.Route {
+				return *service
+			}
+		}
+	}
+	return topology.ServiceTier{}
 }

--- a/generatorreceiver/internal/generator/trace_generator_test.go
+++ b/generatorreceiver/internal/generator/trace_generator_test.go
@@ -11,8 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-// scafolding for tests
-var topoTestFrontend = topology.ServiceTier{
+var topologyTestFrontend = topology.ServiceTier{
 	Routes: map[string]*topology.ServiceRoute{
 		"/product": {
 			DownstreamCalls: []topology.Call{
@@ -21,6 +20,8 @@ var topoTestFrontend = topology.ServiceTier{
 			},
 			MaxLatencyMillis: 20,
 		},
+
+		"/checkout": {MaxLatencyMillis: 20},
 	},
 	TagSets: []topology.TagSet{
 		{
@@ -32,7 +33,7 @@ var topoTestFrontend = topology.ServiceTier{
 	},
 }
 
-var topoTestCatalogService = topology.ServiceTier{
+var topologyTestCatalogService = topology.ServiceTier{
 	Routes: map[string]*topology.ServiceRoute{
 		"/GetProducts": {
 			MaxLatencyMillis: 5,
@@ -48,7 +49,7 @@ var topoTestCatalogService = topology.ServiceTier{
 	},
 }
 
-var topoTestRecommendationService = topology.ServiceTier{
+var topologyTestRecommendationService = topology.ServiceTier{
 	Routes: map[string]*topology.ServiceRoute{
 		"/GetRecommendations": {MaxLatencyMillis: 10},
 	},
@@ -62,22 +63,14 @@ var topoTestRecommendationService = topology.ServiceTier{
 	},
 }
 
-var topoTestFrontendWithoutDownStreamCalls = topology.ServiceTier{
-	Routes: map[string]*topology.ServiceRoute{
-		"/product": {MaxLatencyMillis: 10},
-	},
-}
-
 func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
 
 	type args struct {
-		traces         *ptrace.Traces
 		serviceName    string
 		routeName      string
 		startTimeNanos int64
 	}
 
-	traces := ptrace.NewTraces()
 	tests := []struct {
 		name string
 		topo *topology.Topology
@@ -87,28 +80,12 @@ func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
 			name: "span with downstream calls",
 			topo: &topology.Topology{
 				Services: map[string]*topology.ServiceTier{
-					"frontend":              &topoTestFrontend,
-					"productcatalogservice": &topoTestCatalogService,
-					"recommendationservice": &topoTestRecommendationService,
+					"frontend":              &topologyTestFrontend,
+					"productcatalogservice": &topologyTestCatalogService,
+					"recommendationservice": &topologyTestRecommendationService,
 				},
 			},
 			args: args{
-				traces:         &traces,
-				serviceName:    "frontend",
-				routeName:      "/product",
-				startTimeNanos: 000000123,
-			},
-		},
-
-		{
-			name: "span without downstream calls",
-			topo: &topology.Topology{
-				Services: map[string]*topology.ServiceTier{
-					"frontend": &topoTestFrontendWithoutDownStreamCalls,
-				},
-			},
-			args: args{
-				traces:         &traces,
 				serviceName:    "frontend",
 				routeName:      "/product",
 				startTimeNanos: 000000123,
@@ -118,9 +95,10 @@ func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			traces := ptrace.NewTraces()
 			g := NewTraceGenerator(tt.topo, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
 			genTraceID := g.genTraceId()
-			span := g.createSpanForServiceRouteCall(tt.args.traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
+			span := g.createSpanForServiceRouteCall(&traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
 			convertedSpanStartTime := pcommon.NewTimestampFromTime(time.Unix(0, tt.args.startTimeNanos))
 
 			require.Equal(t, span.StartTimestamp(), convertedSpanStartTime)
@@ -130,21 +108,31 @@ func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
 
 			resourceSpans := traces.ResourceSpans()
 			serviceTier := tt.topo.Services
-			i := 0
+			indexResourceSpans := 0
 
-			for _, value := range serviceTier {
+			for serviceName, value := range serviceTier {
 
 				if len(value.TagSets) > 0 {
 					for tagKey, tagValue := range value.TagSets[0].Tags {
-						retrievedTagValue, exists := resourceSpans.At(i).ScopeSpans().At(0).Spans().At(0).Attributes().Get(tagKey)
+						retrievedTagValue, exists := resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).Attributes().Get(tagKey)
 						require.Equal(t, tagValue, retrievedTagValue.AsString())
 						require.True(t, exists)
-						spanEndTime := resourceSpans.At(i).ScopeSpans().At(0).Spans().At(0).EndTimestamp() //there are no children of children so index 0
-						require.GreaterOrEqual(t, span.EndTimestamp(), spanEndTime)
 					}
-					i++
 				}
 
+				for route := range serviceTier[serviceName].Routes {
+					require.Equal(t, resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).Name(), route)
+				}
+
+				if resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).ParentSpanID() != pcommon.NewSpanIDEmpty() {
+					require.Equal(t, resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).ParentSpanID(), span.SpanID())
+				}
+
+				childSpanStartTime := resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).StartTimestamp()
+				require.LessOrEqual(t, span.StartTimestamp(), childSpanStartTime)
+				childSpanEndTime := resourceSpans.At(indexResourceSpans).ScopeSpans().At(0).Spans().At(0).EndTimestamp() //there are no children of children so index 0
+				require.GreaterOrEqual(t, span.EndTimestamp(), childSpanEndTime)
+				indexResourceSpans++
 			}
 
 		})

--- a/generatorreceiver/internal/generator/trace_generator_test.go
+++ b/generatorreceiver/internal/generator/trace_generator_test.go
@@ -1,0 +1,106 @@
+package generator
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/topology"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+var topoTestFrontend = topology.ServiceTier{
+	Routes: map[string]*topology.ServiceRoute{
+		"/product": {
+			DownstreamCalls: []topology.Call{
+				{"productcatalogservice", "/GetProducts"},
+				{"recommendationservice", "/GetRecommendations"},
+			},
+			MaxLatencyMillis: 100,
+		},
+		"/cart": {
+			DownstreamCalls:  []topology.Call{{"recommendationservice", "/GetRecommendations"}},
+			MaxLatencyMillis: 200,
+		},
+	},
+}
+
+var topoTestCatalogService = topology.ServiceTier{
+	Routes: map[string]*topology.ServiceRoute{"/GetProducts": {
+		MaxLatencyMillis: 300,
+	}},
+}
+
+var topoTestCyclicalCatalogService = topology.ServiceTier{
+	Routes: map[string]*topology.ServiceRoute{
+		"/GetProducts": {
+			DownstreamCalls:  []topology.Call{{"frontend", "/cart"}},
+			MaxLatencyMillis: 400,
+		},
+	},
+}
+
+var topoTestRecommendationService = topology.ServiceTier{
+	Routes: map[string]*topology.ServiceRoute{
+		"/GetRecommendations": {
+			DownstreamCalls:  []topology.Call{{"productcatalogservice", "/GetProducts"}},
+			MaxLatencyMillis: 500,
+		},
+	},
+}
+
+func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
+
+	type args struct {
+		traces         *ptrace.Traces
+		serviceName    string
+		routeName      string
+		startTimeNanos int64
+	}
+
+	traces := ptrace.NewTraces()
+	tests := []struct {
+		name string
+		topo *topology.Topology
+		args args
+	}{
+		{
+			name: "valid args",
+			topo: &topology.Topology{
+				Services: map[string]*topology.ServiceTier{
+					"frontend":              &topoTestFrontend,
+					"productcatalogservice": &topoTestCatalogService,
+					"recommendationservice": &topoTestRecommendationService,
+				},
+			},
+			args: args{
+				traces:         &traces,
+				serviceName:    "frontend",
+				routeName:      "/product",
+				startTimeNanos: 000000123,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewTraceGenerator(tt.topo, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
+			genTraceID := g.genTraceId()
+			span := g.createSpanForServiceRouteCall(tt.args.traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
+			require.Equal(t, span.Name(), tt.args.routeName)
+			require.Equal(t, span.Name(), g.route)
+			require.Equal(t, span.TraceID(), genTraceID)
+			require.Equal(t, span.ParentSpanID(), pcommon.NewSpanIDEmpty())
+
+			convertedStartTime := pcommon.NewTimestampFromTime(time.Unix(0, tt.args.startTimeNanos))
+			require.Equal(t, span.StartTimestamp(), convertedStartTime)
+
+			endTime := tt.args.startTimeNanos + g.topology.Services[tt.args.serviceName].Routes[tt.args.routeName].SampleLatency(genTraceID)
+			convertedEndTime := pcommon.NewTimestampFromTime(time.Unix(0, endTime))
+			require.Equal(t, span.EndTimestamp(), convertedEndTime)
+
+		})
+	}
+}

--- a/generatorreceiver/internal/generator/trace_generator_test.go
+++ b/generatorreceiver/internal/generator/trace_generator_test.go
@@ -94,7 +94,7 @@ func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewTraceGenerator(tt.topo, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
 			genTraceID := g.genTraceId()
-			span := g.createSpanForServiceRouteCall(tt.args.traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty()) // parent span
+			span := g.createSpanForServiceRouteCall(tt.args.traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
 			require.Equal(t, span.Name(), tt.args.routeName)
 			require.Equal(t, span.TraceID(), genTraceID)
 			require.Equal(t, span.ParentSpanID(), pcommon.NewSpanIDEmpty()) //root span will have parent span id of 0

--- a/generatorreceiver/internal/generator/trace_generator_test.go
+++ b/generatorreceiver/internal/generator/trace_generator_test.go
@@ -120,19 +120,18 @@ func TestTraceGenerator_createSpanForServiceRouteCall(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			g := NewTraceGenerator(tt.topo, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
 			genTraceID := g.genTraceId()
-
 			span := g.createSpanForServiceRouteCall(tt.args.traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
+			convertedSpanStartTime := pcommon.NewTimestampFromTime(time.Unix(0, tt.args.startTimeNanos))
+
+			require.Equal(t, span.StartTimestamp(), convertedSpanStartTime)
 			require.Equal(t, span.Name(), tt.args.routeName)
 			require.Equal(t, span.TraceID(), genTraceID)
 			require.Equal(t, span.ParentSpanID(), pcommon.NewSpanIDEmpty()) //root span will have parent span id of 0
 
-			convertedSpanStartTime := pcommon.NewTimestampFromTime(time.Unix(0, tt.args.startTimeNanos))
-			require.Equal(t, span.StartTimestamp(), convertedSpanStartTime)
-
 			resourceSpans := traces.ResourceSpans()
-			serviceTier := tt.topo.Services //get the service tiers from the topology
-
+			serviceTier := tt.topo.Services
 			i := 0
+
 			for _, value := range serviceTier {
 
 				if len(value.TagSets) > 0 {


### PR DESCRIPTION
## What is the current behavior?

there are currently no tests for the trace generation function, specifically `createSpanForServiceRouteCall` which does all the heavy lifting


## What is the new behavior?

Wrote up a unit test to create spans for a trace and then validate equivalency between the values in the created span vs what was passed in.

There are currently 2 test cases. 1 for spans with downstream calls, and 1 without downstream calls.

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x ] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x ] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x ] Other (please describe): test creation

## Does this introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->