### PR TITLE
Minor README.md updates for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install the [OpenTelemetry Collector Builder](https://github.com/open-telemetry/
    1.  `$ cd ~/Code` (or wherever)
    1.  `$ git clone https://github.com/lightstep/telemetry-generator`
    1.  `$ cd telemetry-generator`
-1. Copy `hipster_shop.yaml` to `dev.yaml` for local development. Not strictly necessary but will potentially save heartache and hassle 😅 This file is in .gitignore, so it won't be included in your commits. If you want to share config changes, add them to a new example config file.
+1. Copy `hipster_shop.yaml` to `dev.yaml` for local development. Not strictly necessary (you can point the `TOPO_FILE` environment variable to any config file) but will potentially save heartache and hassle 😅 This file is in .gitignore, so it won't be included in your commits. If you want to share config changes, add them to a new example config file.
    `$ cp examples/hipster_shop.yaml examples/dev.yaml`
 
 ## Environment variables
@@ -38,6 +38,7 @@ To send demo telemetry data to Lightstep, you'll need an access token associated
 
 ```shell
 $ export LS_ACCESS_TOKEN="<your token>"
+$ export LS_ACCESS_TOKEN_INTERNAL="<your token>"
 ```
 
 ### Collector endpoint
@@ -46,6 +47,7 @@ The env var `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` determines the endpoint for dem
 
 ```shell
 $ export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=ingest.lightstep.com:443
+$ export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT_INTERNAL=ingest.lightstep.com:443
 ```
 
 ### Topo file (generatorreceiver config)


### PR DESCRIPTION
## What is the new behavior?

#### TOPO_FILE
Adds a note about `TOPO_FILE` to the "Get the code" section.  I didn't create the `dev.yaml` file when I was just starting to get things up and running because I am lazy, and then by the time I got down to the section about the `TOPO_FILE` env var I had lost context that the two things are connected - it says "Not strictly necessary" but if you're following the default `TOPO_FILE` command of `$ export TOPO_FILE=examples/dev.yaml` then it is necessary 😄 (probably me just being forgetful but it took me a second to figure out what was going on)

#### Internal env vars
Similar thing with the `ACCESS_TOKEN`/`ENDPOINT`  environment variables.  The top section lists both the primary and `internal` variables, but the examples below that only show the primary variable export.  If you're just blindly copy pasting the example commands to get up and running then your build breaks because you haven't set the `internal` ones.  It's not clear that the `internal` ones are required by default.  

It's nice to just setup the one project with the primary variables to get something up and running.  For my use case I had no need for the `internal` telemetry.  (I actually just ended up commenting the `otlp/2` exporter/pipeline)

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
