### PR TITLE
Do not use ReportFatalError in Start(), it will deadlock

### DIFF
--- a/generatorreceiver/generator_receiver.go
+++ b/generatorreceiver/generator_receiver.go
@@ -47,12 +47,12 @@ func (g generatorReceiver) loadTopoFile(topoInline string, path string) (topoFil
 func (g generatorReceiver) Start(ctx context.Context, host component.Host) error {
 	topoFile, err := g.loadTopoFile(g.topoInline, g.topoPath)
 	if err != nil {
-		host.ReportFatalError(err)
+		return fmt.Errorf("could not load topo file: %w", err)
 	}
 
 	err = validateConfiguration(*topoFile)
 	if err != nil {
-		host.ReportFatalError(err)
+		return fmt.Errorf("could not validate topo file: %w", err)
 	}
 
 	g.logger.Info("starting flag manager", zap.Int("flag_count", flags.Manager.FlagCount()))
@@ -160,7 +160,6 @@ func (g *generatorReceiver) startMetricGenerator(ctx context.Context, host compo
 					host.ReportFatalError(err)
 				}
 			}
-
 		}
 	}()
 


### PR DESCRIPTION
## What is the current behavior?
Due to a deadlock in the collector's ReportFatalError, it should not be used in Start().
https://github.com/open-telemetry/opentelemetry-collector/issues/8116

## What is the new behavior?
Start() can return an error to stop the startup sequence.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->