### PR TITLE
Do not fatal for ordinary consume errors

### DIFF
--- a/generatorreceiver/generator_receiver.go
+++ b/generatorreceiver/generator_receiver.go
@@ -134,7 +134,11 @@ func (g generatorReceiver) Start(ctx context.Context, host component.Host) error
 					case <-traceTicker.C:
 						if rootRoute.ShouldGenerate() {
 							traces := traceGen.Generate(time.Now().UnixNano())
-							_ = g.traceConsumer.ConsumeTraces(context.Background(), *traces)
+							err := g.traceConsumer.ConsumeTraces(context.Background(), *traces)
+							if err != nil {
+								g.logger.Error("consume error", zap.Error(err))
+							}
+
 						}
 					}
 				}
@@ -157,7 +161,7 @@ func (g *generatorReceiver) startMetricGenerator(ctx context.Context, host compo
 			if metrics, report := metricGen.Generate(&m, serviceName); report {
 				err := g.metricConsumer.ConsumeMetrics(ctx, metrics)
 				if err != nil {
-					host.ReportFatalError(err)
+					g.logger.Error("consume error", zap.Error(err))
 				}
 			}
 		}


### PR DESCRIPTION
## What is the current behavior?
The collector will exit because of a transient failure.

## What is the new behavior?
It will log the failure.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The process fails in a difficult to diagnose way!
It exits with status 0 and the log explaining why is nowhere near the bottom.