### PR TITLE
Set error span status

### DIFF
--- a/generatorreceiver/internal/generator/trace_generator.go
+++ b/generatorreceiver/internal/generator/trace_generator.go
@@ -119,6 +119,14 @@ func (g *TraceGenerator) createSpanForServiceRouteCall(traces *ptrace.Traces, se
 		endTime = Max(endTime, int64(childSpan.EndTimestamp()))
 	}
 
+	// For some platforms the `error` attribute is not enough to mark a span as an error.
+	// They only look at the span status.
+	_, exists := span.Attributes().Get("error")
+	if exists {
+		span.Status().SetCode(ptrace.StatusCodeError)
+		span.Status().SetMessage("Error")
+	}
+
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, startTimeNanos)))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, endTime)))
 	g.sequenceNumber += 1


### PR DESCRIPTION
The generator config allows us to specify tag sets for each route.
It's convenient to use the `error: true` span attribute to mark a span as an error (I think it came from opentracing). But some systems ignore this tag and only look at the span status. 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

If the `error` tag is specified in route configuration, it's added to the span attributes and propagated to parental spans.
Span status is not modified.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Now when a span has the `error` attribute, the span status is updated to `Error` as suggested in the [OpenTelemetry docs](https://opentelemetry.io/docs/concepts/signals/traces/#span-status).

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->