### PR TITLE
use direct metric export instead of prometheus scraping

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,8 +14,7 @@ jobs:
           go-version: "1.20"
       - uses: actions/checkout@v3
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+      - uses: golangci/golangci-lint-action@v5
         with:
           working-directory: generatorreceiver
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
           working-directory: generatorreceiver
 

--- a/config/collector-config.yml
+++ b/config/collector-config.yml
@@ -3,17 +3,6 @@ receivers:
   generator:
     path: "${TOPO_FILE}"
     inline: "${TOPO_INLINE}"
-  prometheus:
-    config:
-      scrape_configs:
-        - job_name: 'otel-collector'
-          scrape_interval: 5s
-          static_configs:
-            - targets: ['localhost:8888']
-          relabel_configs:
-          - replacement: "telemetry-generator"
-            target_label: "service"
-            action: replace
                
 processors:
   batch:
@@ -34,15 +23,7 @@ exporters:
       "lightstep-access-token": "${LS_ACCESS_TOKEN}"
     sending_queue:
       num_consumers: 20
-      queue_size: 10000  
-  # export internal metrics to monitoring project  
-  otlp/2:
-    endpoint: "${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT_INTERNAL}"
-    tls:
-      insecure_skip_verify: true
-      insecure: "${OTEL_INSECURE}"
-    headers:
-      "lightstep-access-token": "${LS_ACCESS_TOKEN_INTERNAL}"         
+      queue_size: 10000      
 
 service:
   pipelines:
@@ -55,12 +36,6 @@ service:
       exporters:
       - otlp
       - logging
-#pipeline for the collectors own internal metrics      
-    metrics/2:
-      receivers:
-      - prometheus
-      exporters:
-      - otlp/2
     traces:
       receivers:
       - generator
@@ -70,3 +45,19 @@ service:
       exporters:
       - logging
       - otlp
+  telemetry:
+    resource:
+      service.name: telemetry-generator
+      service: telemetry-generator
+      metrics:
+        level: detailed
+        readers:
+          - periodic:
+              exporter:
+                otlp:
+                  endpoint: "${OTEL_EXPORTER_OTLP_TRACES_ENDPOINT_INTERNAL}"
+                  tls:
+                    insecure_skip_verify: true
+                    insecure: "${OTEL_INSECURE}"
+                  headers:
+                    "lightstep-access-token": "${LS_ACCESS_TOKEN_INTERNAL}"         


### PR DESCRIPTION
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
currently uses prometheus metric self-scraping to export monitoring metrics

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

export monitoring metrics directly to lightstep

this will resolve metric type mismatch issues resulting from multiple ways of exporting otelcol metrics to internal lightstep projects

---

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests(`make test`) for the changes have been added (for bug fixes / features) and pass
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Lint (`make lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->