### PR TITLE
[LS-60884] remove uses of rand.Seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 vendor/
 dist/
+.idea/

--- a/generatorreceiver/internal/generator/trace_generator.go
+++ b/generatorreceiver/internal/generator/trace_generator.go
@@ -77,7 +77,7 @@ func (g *TraceGenerator) createSpanForServiceRouteCall(traces *ptrace.Traces, se
 
 	resourceAttributeSet := serviceTier.GetResourceAttributeSet(traceId)
 	attrs := resource.Attributes()
-	resourceAttributeSet.GetAttributes().InsertTags(&attrs)
+	resourceAttributeSet.GetAttributes(g.random).InsertTags(&attrs, g.random)
 
 	rspan.ScopeSpans()
 	ils := rspan.ScopeSpans().AppendEmpty()
@@ -94,7 +94,7 @@ func (g *TraceGenerator) createSpanForServiceRouteCall(traces *ptrace.Traces, se
 
 	ts := serviceTier.GetTagSet(routeName, traceId) // ts is single TagSet consisting of tags from the service AND route
 	attr := span.Attributes()
-	ts.Tags.InsertTags(&attr) // add service and route tags to span attributes
+	ts.Tags.InsertTags(&attr, g.random) // add service and route tags to span attributes
 
 	for _, tg := range ts.TagGenerators {
 		tg.Init(g.random)
@@ -106,9 +106,9 @@ func (g *TraceGenerator) createSpanForServiceRouteCall(traces *ptrace.Traces, se
 	// TODO: this is still a bit weird - we're calling each downstream route
 	// after a sample of the current route's latency, which doesn't really
 	// make sense - but maybe it's realistic enough?
-	endTime := startTimeNanos + route.SampleLatency(traceId)
+	endTime := startTimeNanos + route.SampleLatency(traceId, g.random)
 	for _, c := range route.DownstreamCalls {
-		var childStartTimeNanos = startTimeNanos + route.SampleLatency(traceId)
+		var childStartTimeNanos = startTimeNanos + route.SampleLatency(traceId, g.random)
 
 		childSpan := g.createSpanForServiceRouteCall(traces, c.Service, c.Route, childStartTimeNanos, traceId, newSpanId)
 		val, ok := childSpan.Attributes().Get("error")

--- a/generatorreceiver/internal/generator/trace_generator_test.go
+++ b/generatorreceiver/internal/generator/trace_generator_test.go
@@ -109,7 +109,7 @@ func TestTraceGenerator_createSpanForServiceRouteCall2(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			traces := ptrace.NewTraces()
-			g := NewTraceGenerator(testTopology, rand.New(rand.NewSource(rand.Int63())), tt.args.serviceName, tt.args.routeName)
+			g := NewTraceGenerator(testTopology, rand.New(rand.NewSource(123)), tt.args.serviceName, tt.args.routeName)
 			genTraceID := g.genTraceId()
 			rootSpan := g.createSpanForServiceRouteCall(&traces, g.service, g.route, tt.args.startTimeNanos, genTraceID, pcommon.NewSpanIDEmpty())
 			convertedSpanStartTime := pcommon.NewTimestampFromTime(time.Unix(0, tt.args.startTimeNanos))

--- a/generatorreceiver/internal/topology/kubernetes_test.go
+++ b/generatorreceiver/internal/topology/kubernetes_test.go
@@ -2,6 +2,7 @@ package topology
 
 import (
 	"github.com/stretchr/testify/require"
+	"math/rand"
 	"testing"
 	"time"
 )
@@ -59,13 +60,14 @@ func TestMultiPod(t *testing.T) {
 		},
 		PodCount: nPods,
 	}
-	k.CreatePods("some")
+	random := rand.New(rand.NewSource(123))
+	k.CreatePods("some", random)
 
 	// we should see more than one pod name in the tags
 	// (odds of this test failing randomly are 1 in 7**100 =~ 3 in 10^85
 	names := make(map[string]bool)
 	for i := 0; i < 100; i++ {
-		tags := k.GetRandomK8sTags()
+		tags := k.GetRandomK8sTags(random)
 		names[tags["k8s.pod.name"]] = true
 	}
 	require.Greater(t, len(names), 1, "multiple pod names should be generated")
@@ -90,7 +92,7 @@ func TestMultiPod(t *testing.T) {
 			},
 		},
 	}
-	k.CreatePods("some")
+	k.CreatePods("some", random)
 	require.Equal(t, 2, k.GetPodCount(), "pod count defaults to config value")
 	k = &Kubernetes{
 		ClusterName: "some-cluster",
@@ -99,6 +101,6 @@ func TestMultiPod(t *testing.T) {
 			Jitter: minute,
 		},
 	}
-	k.CreatePods("some")
+	k.CreatePods("some", random)
 	require.Equal(t, 1, k.GetPodCount(), "pod count defaults to 1 if no config value")
 }

--- a/generatorreceiver/internal/topology/latency_percentiles_test.go
+++ b/generatorreceiver/internal/topology/latency_percentiles_test.go
@@ -1,6 +1,7 @@
 package topology
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -52,7 +53,7 @@ func TestLatencyPercentiles_WorksWithoutWeights(t *testing.T) {
 		err := cfg.loadDurations()
 		require.NoError(t, err)
 	}
-
-	latency := cfgs.Sample(pcommon.NewTraceIDEmpty())
+	random := rand.New(rand.NewSource(123))
+	latency := cfgs.Sample(pcommon.NewTraceIDEmpty(), random)
 	require.Equal(t, 100*time.Millisecond, time.Duration(latency))
 }

--- a/generatorreceiver/internal/topology/metric.go
+++ b/generatorreceiver/internal/topology/metric.go
@@ -62,11 +62,11 @@ type Metric struct {
 	Shape               Shape             `json:"shape" yaml:"shape"`
 	ShapeInterface      ShapeInterface    `json:"-" yaml:"-"`
 	Tags                map[string]string `json:"tags" yaml:"tags"`
-	TagGenerator       TagGenerator    `json:"tagGenerator,omitempty" yaml:"tagGenerator,omitempty"`
+	TagGenerator        TagGenerator      `json:"tagGenerator,omitempty" yaml:"tagGenerator,omitempty"`
 	Jitter              float64           `json:"jitter" yaml:"jitter"`
 	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
 	Pod                 *Pod
-	Random *rand.Rand
+	Random              *rand.Rand
 }
 
 func (m *Metric) GetTags() map[string]string {
@@ -74,12 +74,11 @@ func (m *Metric) GetTags() map[string]string {
 		return m.Pod.ReplaceTags(m.Tags)
 	}
 
-
 	tags := make(map[string]string)
-	for k,v := range m.Tags {
+	for k, v := range m.Tags {
 		tags[k] = v
 	}
-	for k,v := range m.TagGenerator.GetRefreshedTags() {
+	for k, v := range m.TagGenerator.GetRefreshedTags() {
 		tags[k] = v
 	}
 
@@ -159,7 +158,7 @@ func (m *Metric) GetValue() float64 {
 	v := m.Min + (m.Max-m.Min)*factor
 
 	// jitter deviation is calculated in percentage that ranges from [-m.Jitter/2, m.Jitter/2)%
-	j := 1 + rand.Float64()*m.Jitter - m.Jitter/2
+	j := 1 + m.Random.Float64()*m.Jitter - m.Jitter/2
 
 	v = v * j
 

--- a/generatorreceiver/internal/topology/resource_attribute_set.go
+++ b/generatorreceiver/internal/topology/resource_attribute_set.go
@@ -2,6 +2,7 @@ package topology
 
 import (
 	"github.com/lightstep/telemetry-generator/generatorreceiver/internal/flags"
+	"math/rand"
 )
 
 type ResourceAttributeSet struct {
@@ -11,13 +12,13 @@ type ResourceAttributeSet struct {
 	flags.EmbeddedFlags `json:",inline" yaml:",inline"`
 }
 
-func (r *ResourceAttributeSet) GetAttributes() *TagMap {
+func (r *ResourceAttributeSet) GetAttributes(random *rand.Rand) *TagMap {
 	tm := make(TagMap)
 	for k, v := range r.ResourceAttributes {
 		tm[k] = v
 	}
 	if k8s := r.Kubernetes; k8s != nil {
-		for k, v := range k8s.GetRandomK8sTags() {
+		for k, v := range k8s.GetRandomK8sTags(random) {
 			tm[k] = v
 		}
 	}

--- a/generatorreceiver/internal/topology/resource_attribute_set_test.go
+++ b/generatorreceiver/internal/topology/resource_attribute_set_test.go
@@ -67,15 +67,17 @@ func TestResourceAttributeSet_GetAttributes(t *testing.T) {
 				ResourceAttributes: tt.resourceAttributes,
 			}
 
+			random := rand.New(rand.NewSource(123))
+
 			if k := resourceAttrSet.Kubernetes; k != nil {
-				randomGenerator := rand.New(rand.NewSource(123))
-				k.CreatePods(tt.service)
+
+				k.CreatePods(tt.service, random)
 
 				// k8s.pod.name structure was copied from CreatePods()
-				tt.expected["k8s.pod.name"] = tt.service + "-" + generateK8sName(10) + "-" + generateK8sName(5)
+				tt.expected["k8s.pod.name"] = tt.service + "-" + generateK8sName(10, random) + "-" + generateK8sName(5, random)
 			}
 
-			require.Equal(t, tt.expected, *resourceAttrSet.GetAttributes())
+			require.Equal(t, tt.expected, *resourceAttrSet.GetAttributes(random))
 		})
 	}
 }

--- a/generatorreceiver/internal/topology/resource_attribute_set_test.go
+++ b/generatorreceiver/internal/topology/resource_attribute_set_test.go
@@ -68,11 +68,10 @@ func TestResourceAttributeSet_GetAttributes(t *testing.T) {
 			}
 
 			if k := resourceAttrSet.Kubernetes; k != nil {
-				rand.Seed(123)
+				randomGenerator := rand.New(rand.NewSource(123))
 				k.CreatePods(tt.service)
 
 				// k8s.pod.name structure was copied from CreatePods()
-				rand.Seed(123)
 				tt.expected["k8s.pod.name"] = tt.service + "-" + generateK8sName(10) + "-" + generateK8sName(5)
 			}
 

--- a/generatorreceiver/internal/topology/resource_attribute_set_test.go
+++ b/generatorreceiver/internal/topology/resource_attribute_set_test.go
@@ -67,16 +67,16 @@ func TestResourceAttributeSet_GetAttributes(t *testing.T) {
 				ResourceAttributes: tt.resourceAttributes,
 			}
 
-			random := rand.New(rand.NewSource(123))
-
 			if k := resourceAttrSet.Kubernetes; k != nil {
-
+				random := rand.New(rand.NewSource(123))
 				k.CreatePods(tt.service, random)
 
 				// k8s.pod.name structure was copied from CreatePods()
+				random = rand.New(rand.NewSource(123))
 				tt.expected["k8s.pod.name"] = tt.service + "-" + generateK8sName(10, random) + "-" + generateK8sName(5, random)
 			}
 
+			random := rand.New(rand.NewSource(123))
 			require.Equal(t, tt.expected, *resourceAttrSet.GetAttributes(random))
 		})
 	}

--- a/generatorreceiver/internal/topology/service_route.go
+++ b/generatorreceiver/internal/topology/service_route.go
@@ -91,10 +91,10 @@ func (r *ServiceRoute) load(route string) error {
 	return nil
 }
 
-func (r *ServiceRoute) SampleLatency(traceID pcommon.TraceID) int64 {
+func (r *ServiceRoute) SampleLatency(traceID pcommon.TraceID, random *rand.Rand) int64 {
 	if r.LatencyConfigs == nil {
-		return rand.Int63n(r.MaxLatencyMillis * 1000000)
+		return random.Int63n(r.MaxLatencyMillis * 1000000)
 	} else {
-		return r.LatencyConfigs.Sample(traceID)
+		return r.LatencyConfigs.Sample(traceID, random)
 	}
 }

--- a/generatorreceiver/internal/topology/tag_map.go
+++ b/generatorreceiver/internal/topology/tag_map.go
@@ -24,7 +24,8 @@ func (tm *TagMap) InsertTags(attr *pcommon.Map, random *rand.Rand) {
 		case bool:
 			attr.PutBool(key, val)
 		case []string:
-			attr.PutStr(key, val[random.Intn(len(val))])
+			r := random.Intn(len(val))
+			attr.PutStr(key, val[r])
 		default:
 			attr.PutStr(key, fmt.Sprint(val))
 		}

--- a/generatorreceiver/internal/topology/tag_map.go
+++ b/generatorreceiver/internal/topology/tag_map.go
@@ -9,7 +9,7 @@ import (
 
 type TagMap map[string]interface{}
 
-func (tm *TagMap) InsertTags(attr *pcommon.Map) {
+func (tm *TagMap) InsertTags(attr *pcommon.Map, random *rand.Rand) {
 	for key, val := range *tm {
 		switch val := val.(type) {
 		case float64:
@@ -24,7 +24,7 @@ func (tm *TagMap) InsertTags(attr *pcommon.Map) {
 		case bool:
 			attr.PutBool(key, val)
 		case []string:
-			attr.PutStr(key, val[rand.Intn(len(val))])
+			attr.PutStr(key, val[random.Intn(len(val))])
 		default:
 			attr.PutStr(key, fmt.Sprint(val))
 		}

--- a/generatorreceiver/internal/topology/tag_set_test.go
+++ b/generatorreceiver/internal/topology/tag_set_test.go
@@ -26,16 +26,16 @@ func TestTagMap_InsertTag(t *testing.T) {
 
 	attr := pcommon.NewMap()
 
-	rand.Seed(123)
-	ts.Tags.InsertTags(&attr)
+	randomGenerator := rand.New(rand.NewSource(123))
+
+	ts.Tags.InsertTags(&attr, randomGenerator)
 
 	expectedAttr := pcommon.NewMap()
 	expectedAttr.PutBool("key1", true)
 	expectedAttr.PutStr("key2", "hi")
 	expectedAttr.PutDouble("key3", 123.123)
 	expectedAttr.PutInt("key4", 10)
-	rand.Seed(123)
-	expectedAttr.PutStr("key5", csvTags[rand.Intn(len(csvTags))])
+	expectedAttr.PutStr("key5", csvTags[randomGenerator.Intn(len(csvTags))])
 
 	require.Equal(t, attr.AsRaw(), expectedAttr.AsRaw())
 }

--- a/generatorreceiver/internal/topology/tag_set_test.go
+++ b/generatorreceiver/internal/topology/tag_set_test.go
@@ -35,6 +35,8 @@ func TestTagMap_InsertTag(t *testing.T) {
 	expectedAttr.PutStr("key2", "hi")
 	expectedAttr.PutDouble("key3", 123.123)
 	expectedAttr.PutInt("key4", 10)
+
+	randomGenerator = rand.New(rand.NewSource(123))
 	expectedAttr.PutStr("key5", csvTags[randomGenerator.Intn(len(csvTags))])
 
 	require.Equal(t, attr.AsRaw(), expectedAttr.AsRaw())

--- a/generatorreceiver/internal/topology/topology.go
+++ b/generatorreceiver/internal/topology/topology.go
@@ -1,6 +1,9 @@
 package topology
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type Topology struct {
 	Services map[string]*ServiceTier `json:"services" yaml:"services"`
@@ -37,7 +40,7 @@ func (t *Topology) traverseServiceGraph(service string, route string, seenCalls 
 	seenCalls[service+route] = true
 	for _, c := range downstreamCalls {
 		if seenCalls[c.Service+c.Route] {
-			return fmt.Errorf(printServiceCycle(orderedCalls, c.Service+c.Route))
+			return errors.New(printServiceCycle(orderedCalls, c.Service+c.Route))
 		}
 
 		err := t.traverseServiceGraph(c.Service, c.Route, seenCalls, append(orderedCalls, c.Service+c.Route))


### PR DESCRIPTION
## What is the current behavior?
`rand.Seed` is deprecated, and this deprecated method being in use is preventing the linter from allowing changes to this repo


## What is the new behavior?
All uses of `rand.Seed(someseed)` are removed. This is replaced with `rand.New(rand.NewSource(someseed))` which is the preferred way to handle this according to doc strings. Instead of using the global `rand` in random generation, the preferred method seems to be to pass down the generator created by `rand.New` so this also passed down generators into any method that uses them

There is a question here of where we should pass generators as function args and where we should just put the generator as a field in the structs, but a bunch of these structs have json annotations that suggest they are read from files and i do not really know how to make sure `rand` gets populated in the case where some of these structs are constructed from json
